### PR TITLE
importlib: prefer importlib.resources over importlib_resources

### DIFF
--- a/pepclibs/helperlibs/ProjectFiles.py
+++ b/pepclibs/helperlibs/ProjectFiles.py
@@ -19,8 +19,13 @@ from pathlib import Path
 
 # TODO: remove the 'importlib_resources' import and use 'importlib.resources' instead when
 #       switching to Python 3.10+. This hack is needed only to support Python 3.9.
-#import importlib.resources
-import importlib_resources
+try:
+    import importlib.resources
+    importlib_resources_files = importlib.resources.files
+except:
+    import importlib_resources
+    importlib_resources_files = importlib_resources.files
+
 from pepclibs.helperlibs import ProcessManager, Logging
 from pepclibs.helperlibs.Exceptions import Error, ErrorNotFound
 
@@ -78,7 +83,7 @@ def get_python_data_package_path(prjname: str) -> Path | None:
             # 'improtlib.resources.files()' into a 'Path' object. Just using 'str()' does not work.
             # However, with 'joinpath()' it is possible to get a string, and then we can convert it
             # to a 'Path' object.
-            multiplexed_path = importlib_resources.files(pkgname)
+            multiplexed_path = importlib_resources_files(pkgname)
             pkgpath = Path(str(multiplexed_path.joinpath(f"../{pkgname}")))
         if pkgpath:
             return pkgpath.resolve()


### PR DESCRIPTION
Using pepc simply by cloning the repo and running pepc fails on importing importlib_resources. Looking at the code, this could be avoided without installing the importlib_resources dependency in recent Python 3 versions, simply by using importlib.resources.

According to the docs, [importlib.resources.files](https://docs.python.org/3/library/importlib.resources.html#importlib.resources.files) got added to the API in Python 3.9, and the only change so far, that is in Python 3.12, does not affect this code.

Therefore I'd propose getting rid of this minor inconvenience by trying to use importlib.resources.file, and only fallback to importlib_resources.files in case importlib.resources.file is not found in the API (Python older than 3.9).

I'm still leaving the TODO comment untouched as a reminder to get rid of the importlib_resources dependency when dropping support of outdated Python 3.

I tested this change with Python 3.13.5 and Python 3.9.23. They both worked fine, and they both successfully used importlib.resources.files.